### PR TITLE
Clean npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ test/
 .github/
 coverage/
 sample/
+*.tgz


### PR DESCRIPTION
`node_modules/mico-spinner` contains unnecessary `mico-spinner-1.0.0.tgz`.

Can you also release new versions via `npx clean-publish` instead of `npm publish`? Right now you `node_modules/mico-spinner/package.json` contains development configs.