### PR TITLE
Fix passing options

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,9 @@ const isInteractive = require('./isInteractive')
 const Spinner = require('./spinner')
 const PlainSpinner = require('./plainSpinner')
 
-const spinnerFactory = function (options) {
+const spinnerFactory = function (...options) {
   let SpinnerFunction = isInteractive() ? Spinner : PlainSpinner
-  return new SpinnerFunction(options)
+  return new SpinnerFunction(...options)
 }
 
 module.exports = spinnerFactory


### PR DESCRIPTION
`Spinner`/`PlainSpinner` has 2 options (`text` and `opts`). So we need to pass all options from `spinnerFactory`.