### PR TITLE
Replace colorette with nanocolors

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Minimalistic spinner for Node.js.
 
-* Only single dependency ([colorette](https://github.com/jorgebucaran/colorette)) without sub-dependencies. In contrast, `ora` has [30 sub-dependencies](https://npm.anvaka.com/#/view/2d/ora).
+* Only single dependency ([Nano Colors](https://github.com/ai/nanocolors)) without sub-dependencies. In contrast, `ora` has [30 sub-dependencies](https://npm.anvaka.com/#/view/2d/ora).
 * Detects Unicode and color support in terminal.
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -71,7 +71,10 @@
   ],
   "jest": {
     "testEnvironment": "node",
-    "modulePathIgnorePatterns": ["./samples/", "./dist"],
+    "modulePathIgnorePatterns": [
+      "./samples/",
+      "./dist"
+    ],
     "coverageThreshold": {
       "global": {
         "statements": 90
@@ -142,7 +145,6 @@
       "ES",
       "GitHub",
       "modifyWebpackConfig",
-      "colorette",
       "mico-spinner",
       "mico",
       "Minimalistic"
@@ -153,6 +155,6 @@
     "version": "0.10.2"
   },
   "dependencies": {
-    "colorette": "^1.2.2"
+    "nanocolors": "^0.1.1"
   }
 }

--- a/plainSpinner.js
+++ b/plainSpinner.js
@@ -1,6 +1,6 @@
 const process = require('process')
 const readline = require('readline')
-const c = require('colorette')
+const c = require('nanocolors')
 
 const logSymbols = require('./logSymbols')
 

--- a/spinner.js
+++ b/spinner.js
@@ -1,6 +1,6 @@
 const process = require('process')
 const readline = require('readline')
-const c = require('colorette')
+const c = require('nanocolors')
 
 const spinnersList = require('./spinnerAnimation')
 const logSymbols = require('./logSymbols')

--- a/test/spinner.test.js
+++ b/test/spinner.test.js
@@ -1,4 +1,4 @@
-const { red, green } = require('colorette')
+const { red, green } = require('nanocolors')
 
 const logSymbols = require('../logSymbols')
 const Spinner = require('../spinner')

--- a/yarn.lock
+++ b/yarn.lock
@@ -3660,6 +3660,11 @@ multimap@^1.1.0:
   resolved "https://registry.yarnpkg.com/multimap/-/multimap-1.1.0.tgz#5263febc085a1791c33b59bb3afc6a76a2a10ca8"
   integrity sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw==
 
+nanocolors@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/nanocolors/-/nanocolors-0.1.1.tgz#1b148b06c6279084709675fb3d699e0cdc668114"
+  integrity sha512-9XCSSmaAkJVops0tOTkt1lUXO8iO7vTYr1X45I8kCbgP2cMS9RvPGVnp/Ou+ISsm9JhKpKCON7zwOFyWcWrzhA==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"


### PR DESCRIPTION
Replace `colorette` with my `nanocolors`. Reasons:

1. `colorette` 2 [broke API](https://github.com/jorgebucaran/colorette/issues/70). Now you need extra color generation for your simple case.
2. I am using `nanocolors` in Size Limit and check-dts`. Having the same color library will reduce `node_modules` size.
3. `nanocolors` a little faster than `colorette`