### PR TITLE
Changed nanocolors to picocolors

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Minimalistic spinner for Node.js.
 
-* Only single dependency ([Nano Colors](https://github.com/ai/nanocolors)) without sub-dependencies. In contrast, `ora` has [30 sub-dependencies](https://npm.anvaka.com/#/view/2d/ora).
+* Only single dependency ([Pico Colors](https://github.com/alexeyraspopov/picocolors)) without sub-dependencies. In contrast, `ora` has [30 sub-dependencies](https://npm.anvaka.com/#/view/2d/ora).
 * Detects Unicode and color support in terminal.
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -158,7 +158,6 @@
     "version": "0.10.2"
   },
   "dependencies": {
-    "nanocolors": "^0.1.1",
     "picocolors": "^0.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -149,7 +149,8 @@
       "mico",
       "Minimalistic",
       "nanocolors",
-      "colorette"
+      "colorette",
+      "pico"
     ]
   },
   "sharec": {
@@ -157,6 +158,7 @@
     "version": "0.10.2"
   },
   "dependencies": {
-    "nanocolors": "^0.1.1"
+    "nanocolors": "^0.1.1",
+    "picocolors": "^0.2.0"
   }
 }

--- a/plainSpinner.js
+++ b/plainSpinner.js
@@ -1,6 +1,6 @@
 const process = require('process')
 const readline = require('readline')
-const c = require('nanocolors')
+const c = require('picocolors')
 
 const logSymbols = require('./logSymbols')
 

--- a/spinner.js
+++ b/spinner.js
@@ -1,6 +1,6 @@
 const process = require('process')
 const readline = require('readline')
-const c = require('nanocolors')
+const c = require('picocolors')
 
 const spinnersList = require('./spinnerAnimation')
 const logSymbols = require('./logSymbols')

--- a/test/spinner.test.js
+++ b/test/spinner.test.js
@@ -1,4 +1,4 @@
-const { red, green } = require('nanocolors')
+const { red, green } = require('picocolors')
 
 const logSymbols = require('../logSymbols')
 const Spinner = require('../spinner')

--- a/yarn.lock
+++ b/yarn.lock
@@ -3660,11 +3660,6 @@ multimap@^1.1.0:
   resolved "https://registry.yarnpkg.com/multimap/-/multimap-1.1.0.tgz#5263febc085a1791c33b59bb3afc6a76a2a10ca8"
   integrity sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw==
 
-nanocolors@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/nanocolors/-/nanocolors-0.1.1.tgz#1b148b06c6279084709675fb3d699e0cdc668114"
-  integrity sha512-9XCSSmaAkJVops0tOTkt1lUXO8iO7vTYr1X45I8kCbgP2cMS9RvPGVnp/Ou+ISsm9JhKpKCON7zwOFyWcWrzhA==
-
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -4032,6 +4027,11 @@ path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
+picocolors@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-0.2.1.tgz#570670f793646851d1ba135996962abad587859f"
+  integrity sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
   version "2.3.0"


### PR DESCRIPTION
As shown by [nanocolor's own benchmarks](https://github.com/ai/nanocolors#benchmarks), [picocolors](https://www.npmjs.com/package/picocolors) is faster and smaller than nanocolors while providing the same API. This PR removes the dependency on nanocolors and instead uses picocolors.